### PR TITLE
Fix unclickable last menu link issue

### DIFF
--- a/guide/assets/css/main.css
+++ b/guide/assets/css/main.css
@@ -4,6 +4,13 @@
 	max-width: 1000px;
 }
 
+/* sidebar */
+
+.sidebar {
+	padding: 30px 0 0;
+	bottom: 40px;
+}
+
 /* regular text blocks */
 
 .markdown-section p {


### PR DESCRIPTION
Fix an issue on Firefox where the last sidebar menu link was basically unclickable. Also lowered the amount of padding-top the sidebar had, since it looked kinda weird.