### PR TITLE
Fix type in FAQ example

### DIFF
--- a/guide/creating-your-bot/common-questions.md
+++ b/guide/creating-your-bot/common-questions.md
@@ -50,7 +50,7 @@ if (member.roles.exists('name', '<role name>')) {
 ### How do I set my avatar?
 
 ```js
-<client>.user.setAvatar('<nickname>');
+<client>.user.setAvatar('<url or path>');
 ```
 
 ### How do I set my playing status?


### PR DESCRIPTION
Somehow it was using "<nickname>" for the `.setAvatar()` example.