### PR TITLE
Add an info message to pages that need them

### DIFF
--- a/guide/command-handling/README.md
+++ b/guide/command-handling/README.md
@@ -1,5 +1,7 @@
 ## File and folder restructuring
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/creating-your-bot/commands-with-user-input).</p>
+
 As mentioned in a previous chapter, unless your bot project is a small one, it's not a very good idea to have a single file with a giant if/else if chain for commands. If you want to implement features into your bot and make your development process a lot less painful, you'll definitely want to use (or in this case, create) a command handler. Let's get started on that!
 
 ### Individual command files

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -1,5 +1,7 @@
 ## Additional features
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/command-handling/dynamic-commands).</p>
+
 The command handler you've been building so far doesn't do much aside from dynamically load and execute commands. Those two things alone are great, but definitely not the only things you want. Before diving into it, let's do some quick refactoring in preparation.
 
 ```diff

--- a/guide/command-handling/dynamic-commands.md
+++ b/guide/command-handling/dynamic-commands.md
@@ -1,5 +1,7 @@
 ## Handling commands
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/command-handling/).</p>
+
 ### How it works
 
 Now that you have a Collection of all our commands, you can use them easily! But before diving straight into it, it'd be a good idea to familiarize yourself with how you'll turn these basic if statements into something much more dynamic and robust. So let's continue with 1 more if statement example, and then we'll move onto the real stuff.

--- a/guide/creating-your-bot/adding-more-commands.md
+++ b/guide/creating-your-bot/adding-more-commands.md
@@ -1,5 +1,7 @@
 ## Adding more commands
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/creating-your-bot/configuration-files).</p>
+
 A bot with nothing but a single command would be really boring, and you probably have a bunch of command ideas floating around in your head already, right? Let's begin, then.
 
 Here's what your message event should currently look like:

--- a/guide/creating-your-bot/commands-with-user-input.md
+++ b/guide/creating-your-bot/commands-with-user-input.md
@@ -1,5 +1,7 @@
 ## Commands with user input (a.k.a. "arguments")
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/creating-your-bot/adding-more-commands).</p>
+
 Sometimes you'll want to determine the result of a command depending on user input. It's a very common case with a very simple solution. This section will teach you how to extract user input from a message and use it in your code. Generally, you'll hear other people refer to this as "arguments", and you should refer to them as that as well.
 
 ### Basic arguments

--- a/guide/creating-your-bot/configuration-files.md
+++ b/guide/creating-your-bot/configuration-files.md
@@ -1,5 +1,7 @@
 ## Configuration files
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/creating-your-bot/).</p>
+
 As you get deeper into development, you may need to interact with sensitive data or data that gets used in multiple locations, such as:
 
 * Database passwords

--- a/guide/sharding/additional-information.md
+++ b/guide/sharding/additional-information.md
@@ -1,5 +1,7 @@
 ## Additional changes
 
+<p class="tip">This page is a follow-up and bases its code off of [the previous page](/sharding/).</p>
+
 Here are some extra topics covered about sharding that you might have concerns about.
 
 ### Client#Shard
@@ -46,7 +48,7 @@ The shardArgs are what you would normally pass if you ran your bot without shard
 There may come a point where you will want to pass functions or arguments from the outer scope into a broadcastEval.
 
 ```js
-client.shard.broadcastEval(`(${funcName})('${arg}')`)
+client.shard.broadcastEval(`(${funcName})('${arg}')`);
 ```
 
 In this small snippet, I am passing an entire function through the eval, and it needs to be encased in parenthesis otherwise it will throw errors on its way there. Another set of parenthesis is needed so the function actually *gets called*. Finally, the passing of the argument itself, which varies slightly depending on what type of argument you are passing. If it's a string, you must wrap it in quotes, otherwise it will be interpreted as is and throw a syntax error, because it won't be a string by the time it gets there.


### PR DESCRIPTION
Quite a few pages assume you're using code from the previous page, which may not always be true - some people might be visiting the link directly and may become confused because of that. This small message should at least clear that up.