### PR TITLE
Split args by space and not \s

### DIFF
--- a/code_samples/command-handling/adding-features/index.js
+++ b/code_samples/command-handling/adding-features/index.js
@@ -21,7 +21,7 @@ client.on('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/\s+/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 	const commandName = args.shift().toLowerCase();
 
 	const command = client.commands.get(commandName)

--- a/code_samples/command-handling/dynamic-commands/index.js
+++ b/code_samples/command-handling/dynamic-commands/index.js
@@ -19,7 +19,7 @@ client.on('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/\s+/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (!client.commands.has(command)) return;

--- a/code_samples/command-handling/file-setup/index.js
+++ b/code_samples/command-handling/file-setup/index.js
@@ -19,7 +19,7 @@ client.on('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/\s+/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/code_samples/creating-your-bot/commands-with-user-input/index.js
+++ b/code_samples/creating-your-bot/commands-with-user-input/index.js
@@ -9,7 +9,7 @@ client.on('ready', () => {
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/\s+/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/code_samples/sequelize/currency/app.js
+++ b/code_samples/sequelize/currency/app.js
@@ -60,7 +60,7 @@ client.on('message', async message => {
 	else if (command === 'transfer') {
 
 		const currentAmount = currency.getBalance(message.author.id);
-		const transferAmount = commandArgs.split(/\s+/).find(arg => !/<@!?\d+>/.test(arg));
+		const transferAmount = commandArgs.split(/ +/).find(arg => !/<@!?\d+>/.test(arg));
 		const transferTarget = message.mentions.users.first();
 
 		if (!transferAmount || isNaN(transferAmount)) return message.channel.send(`Sorry ${message.author}, that's an invalid amount`);

--- a/guide/command-handling/adding-features.md
+++ b/guide/command-handling/adding-features.md
@@ -5,7 +5,7 @@
 The command handler you've been building so far doesn't do much aside from dynamically load and execute commands. Those two things alone are great, but definitely not the only things you want. Before diving into it, let's do some quick refactoring in preparation.
 
 ```diff
-	const args = message.content.slice(prefix.length).split(/\s+/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 -	const command = args.shift().toLowerCase();
 +	const commandName = args.shift().toLowerCase();
 

--- a/guide/command-handling/dynamic-commands.md
+++ b/guide/command-handling/dynamic-commands.md
@@ -23,7 +23,7 @@ So, if you wanted to (assuming that you've copied & pasted all of your commands 
 client.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).split(/\s+/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 	const command = args.shift().toLowerCase();
 
 	if (command === 'ping') {

--- a/guide/creating-your-bot/commands-with-user-input.md
+++ b/guide/creating-your-bot/commands-with-user-input.md
@@ -70,7 +70,7 @@ If you've never done something like this before, this probably isn't what you'd 
 
 ```diff
 - const args = message.content.slice(prefix.length).split(' ');
-+ const args = message.content.slice(prefix.length).split(/\s+/);
++ const args = message.content.slice(prefix.length).split(/ +/);
 ```
 
 ![extra spaces args fixed](assets/img/ibSgjAC.png)

--- a/guide/sequelize/currency.md
+++ b/guide/sequelize/currency.md
@@ -292,7 +292,7 @@ Here we begin to see the power of associations. Even though users and the shop a
 
 ```js
 const currentAmount = currency.getBalance(message.author.id);
-const transferAmount = commandArgs.split(/\s+/g).find(arg => !/<@!?\d+>/g.test(arg));
+const transferAmount = commandArgs.split(/ +/g).find(arg => !/<@!?\d+>/g.test(arg));
 const transferTarget = message.mentions.users.first();
 
 if (!transferAmount || isNaN(transferAmount)) return message.channel.send(`Sorry ${message.author}, that's an invalid amount.`);


### PR DESCRIPTION
This does not make a difference in the majority of situations (as far as I'm concerned), if we ever provide a page for an eval command, this would break in certain situation, and would display some ugly output in many others.

```js
// this works
items.filter(item => {
	return item.hasOwnProperty('active');
});

// this does not; returns `SyntaxError: Unexpected end of input`
items.filter(item => {
 	// some comment
  	return item.hasOwnProperty('active');
});
```

Even though splitting by `\s+` is better in other situations, splitting by just spaces seems better for Discord bots.