### PR TITLE
Fix Reactions on old messages

### DIFF
--- a/code_samples/additional-info/reactions/raw-event.js
+++ b/code_samples/additional-info/reactions/raw-event.js
@@ -15,7 +15,16 @@ client.on('raw', async event => {
 
 	const user = client.users.get(data.user_id);
 	const message = await channel.fetchMessage(data.message_id);
-	const reaction = message.reactions.get(data.emoji.id || data.emoji.name);
+
+	let emoji = ''
+
+	if(data.emoji.id) {
+		emoji = `${data.emoji.name}:${data.emoji.id}`
+	} else {
+		emoji = data.emoji.name
+	}
+
+	const reaction = message.reactions.get(emoji);
 
 	client.emit('messageReactionAdd', reaction, user);
 });

--- a/code_samples/additional-info/reactions/raw-event.js
+++ b/code_samples/additional-info/reactions/raw-event.js
@@ -16,8 +16,6 @@ client.on('raw', async event => {
 	const user = client.users.get(data.user_id);
 	const message = await channel.fetchMessage(data.message_id);
 
-	let emoji = ''
-
 	const emojiKey = (data.emoji.id) ? `${data.emoji.name}:${data.emoji.id}` : data.emoji.name;
 	const reaction = message.reactions.get(emojiKey);
 

--- a/code_samples/additional-info/reactions/raw-event.js
+++ b/code_samples/additional-info/reactions/raw-event.js
@@ -18,13 +18,8 @@ client.on('raw', async event => {
 
 	let emoji = ''
 
-	if(data.emoji.id) {
-		emoji = `${data.emoji.name}:${data.emoji.id}`
-	} else {
-		emoji = data.emoji.name
-	}
-
-	const reaction = message.reactions.get(emoji);
+	const emojiKey = (data.emoji.id) ? `${data.emoji.name}:${data.emoji.id}` : data.emoji.name;
+	const reaction = message.reactions.get(emojiKey);
 
 	client.emit('messageReactionAdd', reaction, user);
 });

--- a/guide/additional-info/reactions.md
+++ b/guide/additional-info/reactions.md
@@ -256,7 +256,7 @@ All that's left is to fetch the actual reaction from the message and emit the ev
 const reaction = message.reactions.get(emojiKey);
 ```
 
-<p class="tip">In the master branch/v12, reactions are keyed by their ID only, not in a `name:ID format.</p>
+<p class="tip">In the master branch/v12, reactions are keyed by their ID only, not in a `name:ID` format.</p>
 
 After that, simply emit the event with the proper data you've built up.
 

--- a/guide/additional-info/reactions.md
+++ b/guide/additional-info/reactions.md
@@ -242,7 +242,7 @@ const message = await channel.fetchMessage(data.message_id);
 
 The if statement in the middle plays an important role; it prevents us from re-emitting the event for both uncached *and* cached messages. Without this, your `messageReactionAdd` event would execute twice for a single reaction if the message was already cached.
 
-A custom emoji contains both a name and an ID, while a unicode emoji contains just a name. Since custom emoji reactions are keyed in a name:ID format and unicode emoji reactions are keyed by their name, you'll have to do something like this to set the right emoji for this event:
+A custom emoji contains both a name and an ID, while a unicode emoji contains just a name. Since custom emoji reactions are keyed in a `name:ID` format and unicode emoji reactions are keyed by their name, you'll have to do something like this to set the right emoji for this event:
 
 ```js
 const emojiKey = (data.emoji.id) ? `${data.emoji.name}:${data.emoji.id}` : data.emoji.name;
@@ -253,10 +253,10 @@ We are checking for `emoji.id` because a unicode emoji won't have an ID inside t
 All that's left is to fetch the actual reaction from the message and emit the event.
 
 ```js
-const reaction = message.reactions.get(emoji);
+const reaction = message.reactions.get(emojiKey);
 ```
 
-<p class="tip">In the master branch/v12 reactions are keyed by their ID only, not by it's name:ID.</p>
+<p class="tip">In the master branch/v12, reactions are keyed by their ID only, not in a `name:ID format.</p>
 
 After that, simply emit the event with the proper data you've built up.
 

--- a/guide/additional-info/reactions.md
+++ b/guide/additional-info/reactions.md
@@ -242,10 +242,24 @@ const message = await channel.fetchMessage(data.message_id);
 
 The if statement in the middle plays an important role; it prevents us from re-emitting the event for both uncached *and* cached messages. Without this, your `messageReactionAdd` event would execute twice for a single reaction if the message was already cached.
 
-All that's left is to fetch the actual reaction from the message and emit the event. Since custom emoji reactions are keyed by their ID and unicode emoji are keyed by their name, you''ll have to do something like this:
+A custom emoji contains both a name and an ID, while a unicode emoji contains just a name. Since custom emoji reactions are keyed by their name:ID and unicode emoji reactions are keyed by their name, you'll have to do something like this to set the right emoji for this event:
 
 ```js
-const reaction = message.reactions.get(data.emoji.id || data.emoji.name);
+let emoji = ''
+            
+if(data.emoji.id) {
+	emoji = `${data.emoji.name}:${data.emoji.id}`
+} else {
+	emoji = data.emoji.name
+}
+```
+
+We are checking for `emoji.id` because a unicode emoji won't have an ID inside the emoji object. Next we are using template literals to combine the name and the ID to create the fulle `name:ID` we need to get the custom emoji reaction.
+
+All that's left is to fetch the actual reaction from the message and emit the event.
+
+```js
+const reaction = message.reactions.get(emoji);
 ```
 
 After that, simply emit the event with the proper data you've built up.

--- a/guide/additional-info/reactions.md
+++ b/guide/additional-info/reactions.md
@@ -242,25 +242,21 @@ const message = await channel.fetchMessage(data.message_id);
 
 The if statement in the middle plays an important role; it prevents us from re-emitting the event for both uncached *and* cached messages. Without this, your `messageReactionAdd` event would execute twice for a single reaction if the message was already cached.
 
-A custom emoji contains both a name and an ID, while a unicode emoji contains just a name. Since custom emoji reactions are keyed by their name:ID and unicode emoji reactions are keyed by their name, you'll have to do something like this to set the right emoji for this event:
+A custom emoji contains both a name and an ID, while a unicode emoji contains just a name. Since custom emoji reactions are keyed in a name:ID format and unicode emoji reactions are keyed by their name, you'll have to do something like this to set the right emoji for this event:
 
 ```js
-let emoji = ''
-            
-if(data.emoji.id) {
-	emoji = `${data.emoji.name}:${data.emoji.id}`
-} else {
-	emoji = data.emoji.name
-}
+const emojiKey = (data.emoji.id) ? `${data.emoji.name}:${data.emoji.id}` : data.emoji.name;
 ```
 
-We are checking for `emoji.id` because a unicode emoji won't have an ID inside the emoji object. Next we are using template literals to combine the name and the ID to create the fulle `name:ID` we need to get the custom emoji reaction.
+We are checking for `emoji.id` because a unicode emoji won't have an ID inside the emoji object. Next we are using template literals to combine the name and the ID to construct the proper key format `name:ID` we need to get the custom emoji reaction.
 
 All that's left is to fetch the actual reaction from the message and emit the event.
 
 ```js
 const reaction = message.reactions.get(emoji);
 ```
+
+<p class="tip">In the master branch/v12 reactions are keyed by their ID only, not by it's name:ID.</p>
 
 After that, simply emit the event with the proper data you've built up.
 


### PR DESCRIPTION
I found out that a custom emoji isn't just mapped by it's ID, but by it's name:ID. The code can be shortened, but for clarity's sake I used an if statement so the reader knows what's going on.