### PR TITLE
Update .setGame() example to .setActivity()

### DIFF
--- a/guide/popular-topics/common-questions.md
+++ b/guide/popular-topics/common-questions.md
@@ -78,7 +78,7 @@ if (<message>.author.id === '<id>') {
 
 <p class="tip">If you're using a selfbot to change your activity, you won't be able to view the status change, but other users will.</p>
 
-<p class="warning">`<client>.user.setActivity()` will only work in v11.3 and above. You can check your version with `npm ls discord.js` and update with `npm install discord.js`. You can still use `<client>.user.setGame()`, but it is now deprecated and removed in v12.</p>
+<p class="warning">`<client>.user.setActivity()` will only work in v11.3 and above. You can check your version with `npm ls discord.js` and update with `npm install discord.js`. You can still use `<client>.user.setGame()`, but it is deprecated as of v11.3, and has been removed in v12.</p>
 
 ## Miscellaneous
 

--- a/guide/popular-topics/common-questions.md
+++ b/guide/popular-topics/common-questions.md
@@ -64,14 +64,21 @@ if (<message>.author.id === '<id>') {
 ### How do I set my playing status?
 
 ```js
-<client>.user.setGame('<game>');
+<client>.user.setActivity('<activity>');
 ```
 
-**Notes:**
+### How do I set my status to "Watching ..." or "Listening to ..."?
 
-* If you would like to set your playing status upon startup, you must place the `<client>.user.setGame()` method in a `ready` event listener (`client.on('ready', () => {});`).
+```js
+<client>.user.setActivity('<activity>', { type: 'WATCHING' });
+<client>.user.setActivity('<activity>', { type: 'LISTENING' });
+```
 
-* If you're using a selfbot to change your playing status, you won't be able to view the status change, but other users will.
+<p class="tip">If you would like to set your activity upon startup, you must place the `<client>.user.setActivity()` method in a `ready` event listener (`<client>.on('ready', () => {});`).</p>
+
+<p class="tip">If you're using a selfbot to change your activity, you won't be able to view the status change, but other users will.</p>
+
+<p class="warning">`<client>.user.setActivity()` will only work in v11.3 and above. You can check your version with `npm ls discord.js` and update with `npm install discord.js`. You can still use `<client>.user.setGame()`, but it is now deprecated and removed in v12.</p>
 
 ## Miscellaneous
 


### PR DESCRIPTION
With v11.3 being released recently, this section needed updating + an addition.
Also moved the notes into `<p class="tip">` tags and added a `<p class="warning">` tag with a note about `ClientUser#setActivity` only being available in v11.3, as well as `ClientUser#setGame`'s deprecation.