### PR TITLE
Fix active sidebar link color from cascading down

### DIFF
--- a/guide/assets/css/dark.css
+++ b/guide/assets/css/dark.css
@@ -21,7 +21,7 @@ body.dark {
 	color: #f3f3f3;
 }
 
-.dark .sidebar ul li.active a {
+.dark .sidebar ul li.active > a {
 	color: #42b983;
 }
 


### PR DESCRIPTION
To prevent [this](https://i.imgur.com/jpMiZFr.png) from becoming [this](https://i.imgur.com/qyQdFQw.png).