### PR TITLE
Fix responsive theme toggle fade issue

### DIFF
--- a/guide/assets/css/main.css
+++ b/guide/assets/css/main.css
@@ -51,6 +51,7 @@ body.close #theme-toggle-button {
 	body.close .sidebar-toggle {
 		background-color: inherit;
 		width: 150px;
+		transition: none;
 	}
 
 	body #theme-toggle-button {


### PR DESCRIPTION
There's this really weird issue that only occurs when viewing the site on mobile devices (or a browser with the window width at <= 768px). If you open the sidebar and click the theme toggle button, the sidebar and theme toggle buttons will fade colors instead of immediately changing like the rest of the site. Tiny PR but this fixes that.