### PR TITLE
Add a smooth fade feature for theme toggling

### DIFF
--- a/guide/assets/css/main.css
+++ b/guide/assets/css/main.css
@@ -1,3 +1,8 @@
+/* body */
+body {
+	transition: color, background-color 0.2s ease-in-out;
+}
+
 /* container width */
 .markdown-section {
 	max-width: 1000px;
@@ -8,6 +13,7 @@
 	bottom: 41px;
 	padding: 30px 0 0;
 	border-right: 1px solid rgba(0, 0, 0, 0.1);
+	transition: color, background-color 0.2s ease-in-out;
 }
 
 .sidebar-toggle {
@@ -22,12 +28,13 @@
 	border-right: 1px solid rgba(0, 0, 0, 0.1);
 	text-align: left;
 	cursor: pointer;
+	transition: color, background-color 0.2s ease-in-out;
 }
 
 .sidebar-toggle i {
 	width: 100%;
 	font-size: 16px;
-	transition: opacity 0.15s ease-in-out;
+	transition: opacity 0.2s ease-in-out;
 }
 
 .sidebar-toggle:hover i {
@@ -51,6 +58,7 @@ body.close #theme-toggle-button {
 	body.close .sidebar-toggle {
 		background-color: inherit;
 		width: 150px;
+		transition: none;
 	}
 
 	body #theme-toggle-button {
@@ -67,6 +75,16 @@ body.close #theme-toggle-button {
 	line-height: 170%;
 }
 
+/* tables */
+.markdown-section tr:nth-child(2n) {
+	transition: background-color 0.2s ease-in-out;
+}
+
+.markdown-section td,
+.markdown-section th {
+	transition: border-color 0.2s ease-in-out;
+}
+
 /* lists */
 .markdown-section ul li,
 .markdown-section ol li {
@@ -80,6 +98,7 @@ body.close #theme-toggle-button {
 	line-height: 125%;
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: 2px;
+	transition: color, background-color 0.2s ease-in-out;
 }
 
 .markdown-section code {
@@ -91,16 +110,18 @@ body.close #theme-toggle-button {
 	line-height: 150%;
 }
 
-.markdown-section pre >code,
+.markdown-section pre > code,
 .markdown-section code {
 	font-size: 0.8rem;
 	font-family: 'Droid Sans Mono', monospace;
+	transition: color, background-color 0.2s ease-in-out;
 }
 
 /* syntax highlighting */
 .token.boolean, .token.constant, .token.deleted, .token.number,
 .token.property, .token.symbol, .token.tag {
 	color: #da3b3b;
+	transition: color 0.2s ease-in-out;
 }
 
 .token.deleted {
@@ -110,6 +131,7 @@ body.close #theme-toggle-button {
 .token.inserted {
 	color: #42b983;
 	border-width: 0;
+	transition: color 0.2s ease-in-out;
 }
 
 /* helper classes */
@@ -126,6 +148,7 @@ body.close #theme-toggle-button {
 
 .markdown-section p.tip {
 	border-color: #42b983;
+	transition: background-color 0.2s ease-in-out;
 }
 
 .markdown-section p.danger {
@@ -139,18 +162,20 @@ body.close #theme-toggle-button {
 .markdown-section p.warning code,
 .markdown-section p.danger code {
 	background-color: #efefef;
+	transition: background-color 0.2s ease-in-out;
 }
 
 .markdown-section p.warning em,
 .markdown-section p.danger em {
 	color: #34495e;
+	transition: color 0.2s ease-in-out;
 }
 
 .markdown-section p.warning::before,
 .markdown-section p.danger::before {
 	border-radius: 100%;
 	color: #fff;
-	content: "!";
+	content: '!';
 	font-family: Dosis, Source Sans Pro, Helvetica Neue, Arial, sans-serif;
 	font-size: 14px;
 	font-weight: 700;
@@ -165,12 +190,21 @@ body.close #theme-toggle-button {
 
 .markdown-section p.tip::before {
 	background-color: #42b983;
+	transition: background-color 0.2s ease-in-out;
 }
 
 .markdown-section p.warning::before {
 	background-color: #f7d24c;
+	transition: background-color 0.2s ease-in-out;
 }
 
 .markdown-section p.danger::before {
 	background-color: #f66;
+	transition: background-color 0.2s ease-in-out;
+}
+
+/* octocat */
+.octo-body,
+.octo-arm {
+	transition: color 0.2s ease-in-out;
 }

--- a/guide/assets/css/main.css
+++ b/guide/assets/css/main.css
@@ -1,6 +1,7 @@
 /* body */
 body {
-	transition: color, background-color 0.2s ease-in-out;
+	transition: all 0.2s ease-in-out;
+	transition-property: color, background-color;
 }
 
 /* container width */
@@ -13,7 +14,8 @@ body {
 	bottom: 41px;
 	padding: 30px 0 0;
 	border-right: 1px solid rgba(0, 0, 0, 0.1);
-	transition: color, background-color 0.2s ease-in-out;
+	transition: all 0.2s ease-in-out;
+	transition-property: color, background-color, transform;
 }
 
 .sidebar-toggle {
@@ -28,7 +30,8 @@ body {
 	border-right: 1px solid rgba(0, 0, 0, 0.1);
 	text-align: left;
 	cursor: pointer;
-	transition: color, background-color 0.2s ease-in-out;
+	transition: all 0.2s ease-in-out;
+	transition-property: color, background-color;
 }
 
 .sidebar-toggle i {
@@ -98,7 +101,8 @@ body.close #theme-toggle-button {
 	line-height: 125%;
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: 2px;
-	transition: color, background-color 0.2s ease-in-out;
+	transition: all 0.2s ease-in-out;
+	transition-property: color, background-color;
 }
 
 .markdown-section code {
@@ -114,7 +118,8 @@ body.close #theme-toggle-button {
 .markdown-section code {
 	font-size: 0.8rem;
 	font-family: 'Droid Sans Mono', monospace;
-	transition: color, background-color 0.2s ease-in-out;
+	transition: all 0.2s ease-in-out;
+	transition-property: color, background-color;
 }
 
 /* syntax highlighting */


### PR DESCRIPTION
Instead of disabling all fade animations, this PR adds a smooth fade animation when toggling, as suggested by @Drahcirius in #66.